### PR TITLE
Use Sass for the styling

### DIFF
--- a/.fluidlintallrc.json
+++ b/.fluidlintallrc.json
@@ -1,10 +1,10 @@
 {
     "sources": {
-        "md": ["src/**/*.md"],
-        "js": ["src/**/*.js", "./*.js"],
-        "json": ["src/**/*.json", "./*.json"],
-        "css": ["src/**/*.css"],
-        "other": ["./.*"]
+        "md": ["./src/**/*.md"],
+        "js": ["./src/**/*.js", "./*.js"],
+        "json": ["./src/**/*.json", "./*.json"],
+        "css": ["./src/css/*.css"],
+        "scss": ["./src/scss/*.scss"]
     },
     "eslint": {
         "js": {
@@ -23,5 +23,8 @@
         "newlines": {
             "excludes": ["tests/**/images/**/*"]
         }
+    },
+    "stylelint": {
+        "excludes": ["./src/css/fluid-covid-map-viz.css"]
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+src/css/fluid-covid-map-viz.css
+src/css/fluid-covid-map-viz.css.map
 build
 node_modules
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -10,17 +10,28 @@ with a mocked accessibility dataset for these assessment centres to visualize at
 
 After checking out this project, run `npm install`.
 
+## Development
+
+The primary styling of this project is written in [Sass](https://sass-lang.com/). At development, to automatically
+watch changes in Scss files and compile into CSS files, run
+
+    npm run watch:scss
+
+To manually compile Scss files into CSS files, run
+
+    npm run build:scss
+
 ## Build & Run
 
 To quickly see the interface in action, load `index.html` from this directory in your browser from a local static HTTP server.
 
 To produce a rolled-up build suitable for deployment run
 
-    node build.js
+    npm run build
 
 To produce a build omitting the Infusion library, run
 
-    node build.js --no-infusion
+    npm run build:noInfusion
 
 The resulting build artefacts will be generated in directory `build`, together with a self-test for the build in
 `build/index.html`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,24 +5,24 @@
     "requires": true,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-            "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+            "version": "7.12.11",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+            "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.12.13"
+                "@babel/highlight": "^7.10.4"
             }
         },
         "@babel/compat-data": {
-            "version": "7.13.12",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.12.tgz",
-            "integrity": "sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==",
+            "version": "7.13.15",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+            "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.13.14",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.14.tgz",
-            "integrity": "sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==",
+            "version": "7.13.15",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz",
+            "integrity": "sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
@@ -30,9 +30,9 @@
                 "@babel/helper-compilation-targets": "^7.13.13",
                 "@babel/helper-module-transforms": "^7.13.14",
                 "@babel/helpers": "^7.13.10",
-                "@babel/parser": "^7.13.13",
+                "@babel/parser": "^7.13.15",
                 "@babel/template": "^7.12.13",
-                "@babel/traverse": "^7.13.13",
+                "@babel/traverse": "^7.13.15",
                 "@babel/types": "^7.13.14",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
@@ -42,6 +42,15 @@
                 "source-map": "^0.5.0"
             },
             "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.12.13",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+                    "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.12.13"
+                    }
+                },
                 "debug": {
                     "version": "4.3.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -246,9 +255,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.13.13",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-            "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+            "version": "7.13.15",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+            "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
             "dev": true
         },
         "@babel/template": {
@@ -260,24 +269,44 @@
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
                 "@babel/types": "^7.12.13"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.12.13",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+                    "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.12.13"
+                    }
+                }
             }
         },
         "@babel/traverse": {
-            "version": "7.13.13",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-            "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+            "version": "7.13.15",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+            "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.13.9",
                 "@babel/helper-function-name": "^7.12.13",
                 "@babel/helper-split-export-declaration": "^7.12.13",
-                "@babel/parser": "^7.13.13",
-                "@babel/types": "^7.13.13",
+                "@babel/parser": "^7.13.15",
+                "@babel/types": "^7.13.14",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
             "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.12.13",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+                    "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.12.13"
+                    }
+                },
                 "debug": {
                     "version": "4.3.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -313,9 +342,9 @@
             }
         },
         "@eslint/eslintrc": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-            "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+            "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
@@ -325,7 +354,6 @@
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^3.13.1",
-                "lodash": "^4.17.20",
                 "minimatch": "^3.0.4",
                 "strip-json-comments": "^3.1.1"
             },
@@ -337,6 +365,15 @@
                     "dev": true,
                     "requires": {
                         "ms": "2.1.2"
+                    }
+                },
+                "globals": {
+                    "version": "12.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+                    "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.8.1"
                     }
                 },
                 "ms": {
@@ -554,6 +591,16 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
             "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
         },
+        "anymatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            }
+        },
         "append-field": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -651,9 +698,9 @@
             "dev": true
         },
         "balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
         "bcrypt-pbkdf": {
@@ -664,6 +711,12 @@
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
+        },
+        "binary-extensions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true
         },
         "body-parser": {
             "version": "1.19.0",
@@ -714,16 +767,16 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-            "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+            "version": "4.16.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+            "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
+                "caniuse-lite": "^1.0.30001208",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.712",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
+                "node-releases": "^1.1.71"
             }
         },
         "buffer-from": {
@@ -779,9 +832,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001205",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
-            "integrity": "sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==",
+            "version": "1.0.30001208",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
+            "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
             "dev": true
         },
         "caseless": {
@@ -817,6 +870,22 @@
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
             "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
             "dev": true
+        },
+        "chokidar": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+            "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+            "dev": true,
+            "requires": {
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.1",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.5.0"
+            }
         },
         "clone-regexp": {
             "version": "2.2.0",
@@ -1253,9 +1322,9 @@
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "electron-to-chromium": {
-            "version": "1.3.704",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.704.tgz",
-            "integrity": "sha512-6cz0jvawlUe4h5AbfQWxPzb+8LzVyswGAWiGc32EJEmfj39HTQyNPkLXirc7+L4x5I6RgRkzua8Ryu5QZqc8cA==",
+            "version": "1.3.717",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
+            "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
             "dev": true
         },
         "emoji-regex": {
@@ -1311,18 +1380,24 @@
             "dev": true
         },
         "escodegen": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+            "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
             "dev": true,
             "requires": {
                 "esprima": "^4.0.1",
-                "estraverse": "^4.2.0",
+                "estraverse": "^5.2.0",
                 "esutils": "^2.0.2",
                 "optionator": "^0.8.1",
                 "source-map": "~0.6.1"
             },
             "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                },
                 "levn": {
                     "version": "0.3.0",
                     "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1372,13 +1447,13 @@
             }
         },
         "eslint": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.19.0.tgz",
-            "integrity": "sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
+            "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@eslint/eslintrc": "^0.3.0",
+                "@babel/code-frame": "7.12.11",
+                "@eslint/eslintrc": "^0.4.0",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -1389,12 +1464,12 @@
                 "eslint-utils": "^2.1.0",
                 "eslint-visitor-keys": "^2.0.0",
                 "espree": "^7.3.1",
-                "esquery": "^1.2.0",
+                "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
-                "file-entry-cache": "^6.0.0",
+                "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^5.0.0",
-                "globals": "^12.1.0",
+                "globals": "^13.6.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
@@ -1402,7 +1477,7 @@
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
@@ -1880,9 +1955,9 @@
             }
         },
         "fluid-lint-all": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fluid-lint-all/-/fluid-lint-all-1.0.0.tgz",
-            "integrity": "sha512-QdPO1mmZkflO/XvdNhd2BcM/UWK00ZKOJsh85xpDLdS5JK9cr15VNSM6bGeKukVWbryNBMNfLZW4BqQUhWrPSQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/fluid-lint-all/-/fluid-lint-all-1.0.4.tgz",
+            "integrity": "sha512-2ZLAKUBXjHwFGmCuHTgCIf7qIhGf89zihnJpKwBPvQ0R+qSA4NIMtn3NwgSTbpJ5jtjQQgiK9IAW5vwyNokYOA==",
             "dev": true,
             "requires": {
                 "@textlint/markdown-to-ast": "6.2.6",
@@ -2021,6 +2096,15 @@
                         "regextras": "^0.7.1",
                         "semver": "^7.3.4",
                         "spdx-expression-parse": "^3.0.1"
+                    }
+                },
+                "globals": {
+                    "version": "12.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+                    "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.8.1"
                     }
                 },
                 "has-flag": {
@@ -2194,6 +2278,13 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "optional": true
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2293,12 +2384,20 @@
             }
         },
         "globals": {
-            "version": "12.4.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-            "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+            "version": "13.8.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+            "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
             "dev": true,
             "requires": {
-                "type-fest": "^0.8.1"
+                "type-fest": "^0.20.2"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.20.2",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+                    "dev": true
+                }
             }
         },
         "globby": {
@@ -2564,12 +2663,6 @@
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
-        "ip-regex": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-            "dev": true
-        },
         "ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2596,6 +2689,15 @@
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
+        },
+        "is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "^2.0.0"
+            }
         },
         "is-boolean-object": {
             "version": "1.1.0",
@@ -2673,9 +2775,9 @@
             "dev": true
         },
         "is-potential-custom-element-name": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
-            "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true
         },
         "is-regexp": {
@@ -2732,9 +2834,9 @@
             "dev": true
         },
         "js-beautify": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.13.5.tgz",
-            "integrity": "sha512-MsXlH6Z/BiRYSkSRW3clNDqDjSpiSNOiG8xYVUBXt4k0LnGvDhlTGOlHX1VFtAdoLmtwjxMG5qiWKy/g+Ipv5w==",
+            "version": "1.13.11",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.13.11.tgz",
+            "integrity": "sha512-+3CW1fQqkV7aXIvprevNYfSrKrASQf02IstAZCVSNh+/IS5ciaOtE7erfjyowdMYZZmP2A7SMFkcJ28qCl84+A==",
             "dev": true,
             "requires": {
                 "config-chain": "^1.1.12",
@@ -2781,37 +2883,51 @@
             "dev": true
         },
         "jsdom": {
-            "version": "16.4.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
-            "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
+            "version": "16.5.3",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
+            "integrity": "sha512-Qj1H+PEvUsOtdPJ056ewXM4UJPCi4hhLA8wpiz9F2YvsRBhuFsXxtrIFAgGBDynQA9isAMGE91PfUYbdMPXuTA==",
             "dev": true,
             "requires": {
-                "abab": "^2.0.3",
-                "acorn": "^7.1.1",
+                "abab": "^2.0.5",
+                "acorn": "^8.1.0",
                 "acorn-globals": "^6.0.0",
                 "cssom": "^0.4.4",
-                "cssstyle": "^2.2.0",
+                "cssstyle": "^2.3.0",
                 "data-urls": "^2.0.0",
-                "decimal.js": "^10.2.0",
+                "decimal.js": "^10.2.1",
                 "domexception": "^2.0.1",
-                "escodegen": "^1.14.1",
+                "escodegen": "^2.0.0",
                 "html-encoding-sniffer": "^2.0.1",
                 "is-potential-custom-element-name": "^1.0.0",
                 "nwsapi": "^2.2.0",
-                "parse5": "5.1.1",
+                "parse5": "6.0.1",
                 "request": "^2.88.2",
-                "request-promise-native": "^1.0.8",
-                "saxes": "^5.0.0",
+                "request-promise-native": "^1.0.9",
+                "saxes": "^5.0.1",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^3.0.1",
+                "tough-cookie": "^4.0.0",
                 "w3c-hr-time": "^1.0.2",
                 "w3c-xmlserializer": "^2.0.0",
                 "webidl-conversions": "^6.1.0",
                 "whatwg-encoding": "^1.0.5",
                 "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.0.0",
-                "ws": "^7.2.3",
+                "whatwg-url": "^8.5.0",
+                "ws": "^7.4.4",
                 "xml-name-validator": "^3.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+                    "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
+                    "dev": true
+                },
+                "ws": {
+                    "version": "7.4.4",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+                    "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+                    "dev": true
+                }
             }
         },
         "jsesc": {
@@ -3083,9 +3199,9 @@
             }
         },
         "map-obj": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.0.tgz",
-            "integrity": "sha512-NAq0fCmZYGz9UFEQyndp7sisrow4GroyGeKluyKC/chuITZsPyOyC1UJZPJlVFImhXdROIP5xqouRLThT3BbpQ==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+            "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
             "dev": true
         },
         "markdown-escapes": {
@@ -3343,13 +3459,13 @@
             }
         },
         "micromatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-            "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
             "dev": true,
             "requires": {
                 "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
+                "picomatch": "^2.2.3"
             }
         },
         "mime": {
@@ -3358,16 +3474,16 @@
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "mime-db": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-            "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+            "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
         },
         "mime-types": {
-            "version": "2.1.29",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-            "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+            "version": "2.1.30",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+            "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
             "requires": {
-                "mime-db": "1.46.0"
+                "mime-db": "1.47.0"
             }
         },
         "min-indent": {
@@ -3458,18 +3574,18 @@
             }
         },
         "node-jqunit": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/node-jqunit/-/node-jqunit-1.1.8.tgz",
-            "integrity": "sha1-Wq1LJ5hHVMoPZ1AmNPEwAt6+GNM=",
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/node-jqunit/-/node-jqunit-1.1.9.tgz",
+            "integrity": "sha512-BrpmY1IkLm8P8dEklihFTYcmGBBqdx5/3FVBJHyhGIcIZwwlgf0IinjHt1767tYyXzLPn+8mnvpzbfrGr3dSNA==",
             "dev": true,
             "requires": {
-                "infusion": "3.0.0-dev.20171117T095227Z.67ff934"
+                "infusion": "3.0.0-dev.20210312T233557Z.0b016a6dc.FLUID-6580"
             },
             "dependencies": {
                 "infusion": {
-                    "version": "3.0.0-dev.20171117T095227Z.67ff934",
-                    "resolved": "https://registry.npmjs.org/infusion/-/infusion-3.0.0-dev.20171117T095227Z.67ff934.tgz",
-                    "integrity": "sha1-0Ng2s0OqbbiMDez+rnHmJ11BQg4=",
+                    "version": "3.0.0-dev.20210312T233557Z.0b016a6dc.FLUID-6580",
+                    "resolved": "https://registry.npmjs.org/infusion/-/infusion-3.0.0-dev.20210312T233557Z.0b016a6dc.FLUID-6580.tgz",
+                    "integrity": "sha512-TTwK+cHM5y/Oz13ueySZHN6Tb3CqkH5wA4hrdFxu3PdIKwPrQzoyAEz8tDcogebMFwAl3yHVwayTO8vJeITq4A==",
                     "dev": true,
                     "requires": {
                         "fluid-resolve": "1.3.0"
@@ -3512,6 +3628,12 @@
                 "semver": "^7.3.4",
                 "validate-npm-package-license": "^3.0.1"
             }
+        },
+        "normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true
         },
         "normalize-range": {
             "version": "0.1.2",
@@ -3649,9 +3771,9 @@
             }
         },
         "parse5": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-            "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
             "dev": true
         },
         "parseurl": {
@@ -3704,9 +3826,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
             "dev": true
         },
         "postcss": {
@@ -3986,9 +4108,9 @@
             },
             "dependencies": {
                 "hosted-git-info": {
-                    "version": "2.8.8",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-                    "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+                    "version": "2.8.9",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+                    "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
                     "dev": true
                 },
                 "normalize-package-data": {
@@ -4037,6 +4159,15 @@
                 "inherits": "~2.0.1",
                 "isarray": "0.0.1",
                 "string_decoder": "~0.10.x"
+            }
+        },
+        "readdirp": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+            "dev": true,
+            "requires": {
+                "picomatch": "^2.2.1"
             }
         },
         "redent": {
@@ -4339,6 +4470,15 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
+        "sass": {
+            "version": "1.32.8",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
+            "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
+            "dev": true,
+            "requires": {
+                "chokidar": ">=2.0.0 <4.0.0"
+            }
+        },
         "saxes": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -4640,9 +4780,9 @@
             "dev": true
         },
         "stylelint": {
-            "version": "13.9.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.9.0.tgz",
-            "integrity": "sha512-VVWH2oixOAxpWL1vH+V42ReCzBjW2AeqskSAbi8+3OjV1Xg3VZkmTcAqBZfRRvJeF4BvYuDLXebW3tIHxgZDEg==",
+            "version": "13.12.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.12.0.tgz",
+            "integrity": "sha512-P8O1xDy41B7O7iXaSlW+UuFbE5+ZWQDb61ndGDxKIt36fMH50DtlQTbwLpFLf8DikceTAb3r6nPrRv30wBlzXw==",
             "dev": true,
             "requires": {
                 "@stylelint/postcss-css-in-js": "^0.37.2",
@@ -4655,7 +4795,7 @@
                 "execall": "^2.0.0",
                 "fast-glob": "^3.2.5",
                 "fastest-levenshtein": "^1.0.12",
-                "file-entry-cache": "^6.0.0",
+                "file-entry-cache": "^6.0.1",
                 "get-stdin": "^8.0.0",
                 "global-modules": "^2.0.0",
                 "globby": "^11.0.2",
@@ -4664,8 +4804,8 @@
                 "ignore": "^5.1.8",
                 "import-lazy": "^4.0.0",
                 "imurmurhash": "^0.1.4",
-                "known-css-properties": "^0.20.0",
-                "lodash": "^4.17.20",
+                "known-css-properties": "^0.21.0",
+                "lodash": "^4.17.21",
                 "log-symbols": "^4.0.0",
                 "mathml-tag-names": "^2.1.3",
                 "meow": "^9.0.0",
@@ -4685,7 +4825,7 @@
                 "resolve-from": "^5.0.0",
                 "slash": "^3.0.0",
                 "specificity": "^0.4.1",
-                "string-width": "^4.2.0",
+                "string-width": "^4.2.2",
                 "strip-ansi": "^6.0.0",
                 "style-search": "^0.1.0",
                 "sugarss": "^2.0.0",
@@ -4748,6 +4888,12 @@
                     "version": "5.1.8",
                     "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
                     "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                    "dev": true
+                },
+                "known-css-properties": {
+                    "version": "0.21.0",
+                    "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
+                    "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
                     "dev": true
                 },
                 "meow": {
@@ -4897,9 +5043,9 @@
                     "dev": true
                 },
                 "hosted-git-info": {
-                    "version": "2.8.8",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-                    "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+                    "version": "2.8.9",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+                    "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
                     "dev": true
                 },
                 "ignore": {
@@ -5160,9 +5306,9 @@
             "dev": true
         },
         "table": {
-            "version": "6.0.9",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.0.9.tgz",
-            "integrity": "sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.1.0.tgz",
+            "integrity": "sha512-T4G5KMmqIk6X87gLKWyU5exPpTjLjY5KyrFWaIjv3SvgaIUGXV7UEzGEnZJdTA38/yUS6f9PlKezQ0bYXG3iIQ==",
             "dev": true,
             "requires": {
                 "ajv": "^8.0.1",
@@ -5177,9 +5323,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.0.3",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.0.3.tgz",
-                    "integrity": "sha512-Df6NAivu9KpZw+q8ySijAgLvr1mUA5ihkRvCLCxpdYR21ann5yIuN+PpFxmweSj7i3yjJ0x5LN5KVs0RRzskAQ==",
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+                    "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -5197,9 +5343,9 @@
             }
         },
         "terser": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.5.1.tgz",
-            "integrity": "sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.6.1.tgz",
+            "integrity": "sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
@@ -5242,14 +5388,22 @@
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
         },
         "tough-cookie": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-            "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+            "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
             "dev": true,
             "requires": {
-                "ip-regex": "^2.1.0",
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.1.2"
+            },
+            "dependencies": {
+                "universalify": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+                    "dev": true
+                }
             }
         },
         "tr46": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
         "lint": "fluid-lint-all",
         "build:scss": "sass src/css/scss/fluid-covid-map-viz.scss src/css/fluid-covid-map-viz.css",
         "watch:scss": "sass --watch src/css/scss/fluid-covid-map-viz.scss src/css/fluid-covid-map-viz.css",
-        "build": "npm run build:scss; node build.js",
-        "build:noInfusion": "npm run build:scss; node build.js --no-infusion",
+        "build": "npm run build:scss && node build.js",
+        "build:noInfusion": "npm run build:scss && node build.js --no-infusion",
         "pretest": "node node_modules/rimraf/bin.js coverage/* reports/* instrumented/*",
         "test": "node node_modules/nyc/bin/nyc.js node tests/all-tests.js"
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
     "description": "We Count Data Monitor project visualising Ontario Covid test centre data as accessible map",
     "scripts": {
         "lint": "fluid-lint-all",
+        "build:scss": "sass src/css/scss/fluid-covid-map-viz.scss src/css/fluid-covid-map-viz.css",
+        "watch:scss": "sass --watch src/css/scss/fluid-covid-map-viz.scss src/css/fluid-covid-map-viz.css",
+        "build": "npm run build:scss; node build.js",
+        "build:noInfusion": "npm run build:scss; node build.js --no-infusion",
         "pretest": "node node_modules/rimraf/bin.js coverage/* reports/* instrumented/*",
         "test": "node node_modules/nyc/bin/nyc.js node tests/all-tests.js"
     },
@@ -24,15 +28,16 @@
         "accessible-autocomplete": "2.0.3"
     },
     "devDependencies": {
-        "node-jqunit": "1.1.8",
-        "eslint": "7.19.0",
+        "node-jqunit": "1.1.9",
+        "eslint": "7.24.0",
         "eslint-config-fluid": "2.0.0",
-        "fluid-lint-all": "1.0.0",
-        "stylelint": "13.9.0",
+        "fluid-lint-all": "1.0.4",
+        "stylelint": "13.12.0",
         "stylelint-config-fluid": "0.1.0",
-        "terser": "5.5.1",
+        "terser": "5.6.1",
         "fs-extra": "9.1.0",
-        "jsdom": "16.4.0",
-        "js-beautify": "1.13.5"
+        "jsdom": "16.5.3",
+        "js-beautify": "1.13.11",
+        "sass": "1.32.8"
     }
 }

--- a/src/css/scss/fluid-covid-map-viz.scss
+++ b/src/css/scss/fluid-covid-map-viz.scss
@@ -19,10 +19,12 @@ h3,
 /******** Shared selectors ********/
 
 /* For all hoverable elements */
-.fl-mapviz-hoverable-focusable:focus,
-.fl-mapviz-hoverable-focusable:hover {
-    outline: 1px solid #000;
-    outline-offset: 1px;
+.fl-mapviz-hoverable-focusable {
+    &:focus,
+    &:hover {
+        outline: 1px solid #000;
+        outline-offset: 1px;
+    }
 }
 
 .fl-mapviz-icon-shadow {
@@ -35,11 +37,11 @@ h3,
     justify-content: center;
     margin-right: 0.7rem;
     width: 1.5rem;
-}
 
-.fl-mapviz-icon-shadow svg {
-    height: 0.8rem;
-    width: 0.8rem;
+    svg {
+        height: 0.8rem;
+        width: 0.8rem;
+    }
 }
 
 /******** Override leaflet.css ********/
@@ -56,23 +58,25 @@ h3,
 }
 
 /** Override the leaflet.css so that the zoom buttons shows below the search box on the mobile design **/
-.leaflet-control-container div:nth-child(1) {
-    z-index: 0;
-}
+.leaflet-control-container {
+    div:nth-child(1) {
+        z-index: 0;
+    }
 
-.leaflet-control-container .leaflet-control-zoom {
-    margin-top: 3rem;
-    z-index: 0;
-}
+    .leaflet-control-zoom {
+        margin-top: 3rem;
+        z-index: 0;
 
-.leaflet-control-container .leaflet-control-zoom a:hover,
-.leaflet-control-container .leaflet-control-zoom a:focus {
-    box-shadow: 0 0 0 1px black inset;
-}
+        a:hover,
+        a:focus {
+            box-shadow: 0 0 0 1px black inset;
+        }
 
-.leaflet-control-container .leaflet-control-zoom a:active {
-    background-color: black;
-    color: white;
+        a:active {
+            background-color: black;
+            color: white;
+        }
+    }
 }
 
 /******** Override accessible-autocomplete.css ********/
@@ -102,34 +106,34 @@ h3,
     position: absolute;
     width: 100%;
     z-index: 999;
-}
 
-.fl-mapviz-query-wrapper > svg {
-    height: 1.5rem;
-    padding-left: 1rem;
-    padding-top: 0.7rem;
-    position: absolute;
-    width: 1.5rem;
-    z-index: 1;
+    & > svg {
+        height: 1.5rem;
+        padding-left: 1rem;
+        padding-top: 0.7rem;
+        position: absolute;
+        width: 1.5rem;
+        z-index: 1;
+    }
 }
 
 .fl-mapviz-query-holder {
     margin: 0.5rem;
-}
 
-.fl-mapviz-query-holder input {
-    background-color: white;
-    border: 1px solid black;
-    border-radius: 1.5rem;
-    height: 2rem;
-    padding-left: 2.5rem;
-    width: 100%;
-}
+    input {
+        background-color: white;
+        border: 1px solid black;
+        border-radius: 1.5rem;
+        height: 2rem;
+        padding-left: 2.5rem;
+        width: 100%;
+    }
 
-/** This markup is injected by the autocomplete widget **/
-.fl-mapviz-query-holder ul {
-    margin-block-end: 0;
-    margin-block-start: 0;
+    /** This markup is injected by the autocomplete widget **/
+    ul {
+        margin-block-end: 0;
+        margin-block-start: 0;
+    }
 }
 
 /** The reset icon in the query box **/
@@ -143,12 +147,12 @@ h3,
     right: 0.6rem;
     top: 0.5rem;
     z-index: 900;
-}
 
-.fl-mapviz-query-reset svg {
-    height: 1rem;
-    width: 1rem;
-    z-index: 1;
+    svg {
+        height: 1rem;
+        width: 1rem;
+        z-index: 1;
+    }
 }
 
 /******** The accessibility filters panel **********/
@@ -158,19 +162,19 @@ h3,
 
 .fl-mapviz-filter-panel {
     max-width: 100%;
+
+    h2 {
+        margin: 1rem 0;
+        margin-left: auto;
+        margin-right: auto;
+        text-align: left;
+        text-transform: uppercase;
+    }
 }
 
 .fl-mapviz-filter-panel-title {
     display: flex;
     flex-direction: row;
-}
-
-.fl-mapviz-filter-panel h2 {
-    margin: 1rem 0;
-    margin-left: auto;
-    margin-right: auto;
-    text-align: left;
-    text-transform: uppercase;
 }
 
 /* All a11y feature list */
@@ -213,16 +217,16 @@ h3,
     height: 1.3rem;
     margin-bottom: 3.125rem;
     width: 1.3rem;
-}
 
-.fl-mapviz-filter-tooltip-icon:active {
-    --tooltip-char-color: white;
-    --tooltip-bg-color: black;
-}
+    &:active {
+        --tooltip-char-color: white;
+        --tooltip-bg-color: black;
+    }
 
-.fl-mapviz-filter-tooltip-icon svg {
-    height: 1.25rem;
-    width: 1.25rem;
+    svg {
+        height: 1.25rem;
+        width: 1.25rem;
+    }
 }
 
 /* The title of each a11y feature */
@@ -238,42 +242,42 @@ h3,
 
 .fl-checkbox-holder {
     margin-right: 0.5rem;
-}
 
-.fl-checkbox-holder > span {
-    border: 2px solid black;
-    box-sizing: border-box;
-    display: inline-block;
-    height: 2rem;
-    position: relative;
-    vertical-align: middle;
-    width: 2rem;
-}
+    & > span {
+        border: 2px solid black;
+        box-sizing: border-box;
+        display: inline-block;
+        height: 2rem;
+        position: relative;
+        vertical-align: middle;
+        width: 2rem;
+    }
 
-.fl-checkbox-holder > span:hover,
-.fl-checkbox-holder > input:focus + span {
-    outline: 1px solid #000;
-    outline-offset: 2px;
-}
+    & > input {
+        -webkit-appearance: none;
+        appearance: none;
+    }
 
-.fl-checkbox-holder > input {
-    -webkit-appearance: none;
-    appearance: none;
-}
+    & > span:hover,
+    & > input:focus + span {
+        outline: 1px solid #000;
+        outline-offset: 2px;
+    }
 
-.fl-checkbox-holder svg {
-    /** The checkbox is not quite correctly sized and doesn't fill its box **/
-    height: 2rem;
-    left: -0.125rem;
+    svg {
+        /** The checkbox is not quite correctly sized and doesn't fill its box **/
+        height: 2rem;
+        left: -0.125rem;
 
-    /** On Firefox, the SVG will take up an unpredictable amount of extra space in the layout **/
-    position: absolute;
-    top: -0.125rem;
-    width: 2rem;
-}
+        /** On Firefox, the SVG will take up an unpredictable amount of extra space in the layout **/
+        position: absolute;
+        top: -0.125rem;
+        width: 2rem;
+    }
 
-.fl-checkbox-holder input:not(:checked) + span .fl-checkbox-selected {
-    display: none;
+    input:not(:checked) + span .fl-checkbox-selected {
+        display: none;
+    }
 }
 
 /* The parent container of filter buttons */
@@ -291,20 +295,17 @@ h3,
     display: inline-flex;
     height: 3rem;
     width: 11rem;
-}
 
-.fl-mapviz-apply-filters svg,
-.fl-mapviz-reset-filters svg {
-    fill: none;
-    height: 1rem;
-    width: 1rem;
-}
+    svg {
+        fill: none;
+        height: 1rem;
+        width: 1rem;
+    }
 
-.fl-mapviz-apply-filters:hover .fl-mapviz-icon-shadow,
-.fl-mapviz-apply-filters:focus .fl-mapviz-icon-shadow,
-.fl-mapviz-reset-filters:hover .fl-mapviz-icon-shadow,
-.fl-mapviz-reset-filters:focus .fl-mapviz-icon-shadow {
-    box-shadow: 0 0 4px rgba(0, 0, 0, 0.25) inset, 0 0 0 1px black;
+    &:hover .fl-mapviz-icon-shadow,
+    &:focus .fl-mapviz-icon-shadow {
+        box-shadow: 0 0 4px rgba(0, 0, 0, 0.25) inset, 0 0 0 1px black;
+    }
 }
 
 /******** Expand/collapse button for the city list panel, the search results panel and the a11y filter panel ********/
@@ -315,35 +316,35 @@ h3,
     justify-content: center;
 }
 
-.fl-mapviz-expand-collapse-button {
-    align-self: center;
-    background: none;
-    border: none;
-    margin: 0.5rem 0 0.5rem 0;
-    width: 4rem;
-}
-
-.fl-mapviz-expand-collapse-button svg {
-    height: 0.7rem;
-    width: 1.4rem;
-}
-
 .expand-collapse-svg-internal-class {
     fill: var(--expand-button-color, none);
     stroke: var(--expand-button-stroke-color, black);
     stroke-width: var(--expand-button-stroke-width, 2px);
 }
 
-.fl-mapviz-expand-collapse-button:hover,
-.fl-mapviz-expand-collapse-button:focus {
-    --expand-button-color: black;
-    --expand-button-stroke-width: 0;
-}
+.fl-mapviz-expand-collapse-button {
+    align-self: center;
+    background: none;
+    border: none;
+    margin: 0.5rem 0 0.5rem 0;
+    width: 4rem;
 
-/* Show/hide the expand or the collapse SVG based on the expanded state */
-.fl-mapviz-expand-collapse-button[aria-expanded="true"] > .fl-mapviz-expand-button,
-.fl-mapviz-expand-collapse-button[aria-expanded="false"] > .fl-mapviz-collapse-button {
-    display: none;
+    svg {
+        height: 0.7rem;
+        width: 1.4rem;
+    }
+
+    &:hover,
+    &:focus {
+        --expand-button-color: black;
+        --expand-button-stroke-width: 0;
+    }
+
+    /* Show/hide the expand or the collapse SVG based on the expanded state */
+    &[aria-expanded="true"] > .fl-mapviz-expand-button,
+    &[aria-expanded="false"] > .fl-mapviz-collapse-button {
+        display: none;
+    }
 }
 
 /******** The city list panel ********/
@@ -354,16 +355,16 @@ h3,
     flex-direction: row;
     justify-content: center;
     padding: 0.5rem 2rem;
-}
 
-.fl-mapviz-city-list-title h2 {
-    margin: 0 1rem 0 0;
-    text-transform: uppercase;
-}
+    h2 {
+        margin: 0 1rem 0 0;
+        text-transform: uppercase;
+    }
 
-.fl-mapviz-city-list-title svg {
-    height: 1.5rem;
-    width: 1.5rem;
+    svg {
+        height: 1.5rem;
+        width: 1.5rem;
+    }
 }
 
 .fl-mapviz-cities {
@@ -402,25 +403,21 @@ h3,
     justify-content: center;
     padding: 0.5rem 0 0.5rem 0.5rem;
     width: 100%;
-}
 
-.fl-mapviz-search-results-back-button svg,
-.fl-mapviz-hospital-back-button svg {
-    height: 1rem;
-    width: 1rem;
-}
+    svg {
+        height: 1rem;
+        width: 1rem;
+    }
 
-.fl-mapviz-search-results-back-button h2,
-.fl-mapviz-hospital-back-button h2 {
-    align-self: center;
-    margin: 0;
-}
+    h2 {
+        align-self: center;
+        margin: 0;
+    }
 
-.fl-mapviz-search-results-back-button:hover .fl-mapviz-icon-shadow,
-.fl-mapviz-search-results-back-button:focus .fl-mapviz-icon-shadow,
-.fl-mapviz-hospital-back-button:hover .fl-mapviz-icon-shadow,
-.fl-mapviz-hospital-back-button:focus .fl-mapviz-icon-shadow {
-    box-shadow: 0 0 4px rgba(0, 0, 0, 0.25) inset, 0 0 0 1px black;
+    &:hover .fl-mapviz-icon-shadow,
+    &:focus .fl-mapviz-icon-shadow {
+        box-shadow: 0 0 4px rgba(0, 0, 0, 0.25) inset, 0 0 0 1px black;
+    }
 }
 
 /* Search result list */
@@ -463,20 +460,20 @@ h3,
 /* hide the hospital description panel at the page load */
 .fl-mapviz-hospital-panel {
     display: none;
+
+    .fl-mapviz-hospital-description {
+        overflow-y: scroll;
+
+        & > div {
+            padding: 0.3rem;
+        }
+    }
 }
 
 .fl-mapviz-hospital-title {
     background: #fbdc90;
     margin: 0;
     padding: 0.5rem;
-}
-
-.fl-mapviz-hospital-panel .fl-mapviz-hospital-description {
-    overflow-y: scroll;
-}
-
-.fl-mapviz-hospital-panel .fl-mapviz-hospital-description > div {
-    padding: 0.3rem;
 }
 
 /******** The panel control buttons ********/
@@ -487,11 +484,11 @@ h3,
     height: 3rem;
     padding-top: 3px;
     z-index: 1;
-}
 
-.fl-panel-controls-on-mobile svg {
-    height: 1rem;
-    width: 1rem;
+    svg {
+        height: 1rem;
+        width: 1rem;
+    }
 }
 
 .fl-mapviz-locations-button-on-mobile,
@@ -502,17 +499,17 @@ h3,
 
 .fl-mapviz-filter-button-on-mobile {
     border-left: 1px solid #c4c4c4;
-}
 
-.fl-mapviz-filter-button-on-mobile .fl-mapviz-filter-icon-on-mobile {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    margin-bottom: 0.3rem;
-}
+    .fl-mapviz-filter-icon-on-mobile {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        margin-bottom: 0.3rem;
 
-.fl-mapviz-filter-button-on-mobile .fl-mapviz-filter-icon-on-mobile svg {
-    margin-right: 0.5rem;
+        svg {
+            margin-right: 0.5rem;
+        }
+    }
 }
 
 /** Background for each a11y filter row **/
@@ -552,18 +549,18 @@ h3,
     top: 1.25rem;
     width: 20rem;
     z-index: 800;
-}
 
-.fl-mapviz-map-tooltip tr:nth-child(even) {
-    background: #eee;
-}
+    table {
+        border-collapse: collapse;
+    }
 
-.fl-mapviz-map-tooltip tr:nth-child(odd) {
-    background: #fff;
-}
+    tr:nth-child(even) {
+        background: #eee;
+    }
 
-.fl-mapviz-map-tooltip table {
-    border-collapse: collapse;
+    tr:nth-child(odd) {
+        background: #fff;
+    }
 }
 
 @media screen and (min-width: 1024px) {
@@ -582,11 +579,11 @@ h3,
     .fl-mapviz-icon-shadow {
         height: 2rem;
         width: 2rem;
-    }
 
-    .fl-mapviz-icon-shadow svg {
-        height: 1rem;
-        width: 1rem;
+        svg {
+            height: 1rem;
+            width: 1rem;
+        }
     }
 
     /** Override the leaflet.css so that the zoom buttons shows below the search box on the mobile design **/
@@ -708,20 +705,20 @@ h3,
         justify-content: center;
         margin-right: 0.7rem;
         width: 3.5rem;
+
+        .fl-mapviz-filter-count-on-desktop {
+            margin: 0 0.5rem;
+        }
+
+        svg {
+            height: 2rem;
+            margin-left: 0.5rem;
+            width: 1.5rem;
+        }
     }
 
     .fl-mapviz-filter-panel-title {
         margin-left: 1rem;
-    }
-
-    .fl-mapviz-filter-count-holder-on-desktop .fl-mapviz-filter-count-on-desktop {
-        margin: 0 0.5rem;
-    }
-
-    .fl-mapviz-filter-count-holder-on-desktop svg {
-        height: 2rem;
-        margin-left: 0.5rem;
-        width: 1.5rem;
     }
 
     /* The a11y filter list */


### PR DESCRIPTION
This pull request converts the original `src/css/fluid-covid-map-viz.css` into the Scss format at `src/css/fluid-covid-map-viz.scss`. Using Sass will help to reduce the workload to adapt the styling to work with UIO.

This PR is based off https://github.com/inclusive-design/covid-data-monitor/pull/10, which needs to be merged first.

[This PR comparison view](https://github.com/cindyli/covid-data-monitor/compare/improve-css...cindyli:use-sass) will make it easier to review the difference between https://github.com/inclusive-design/covid-data-monitor/pull/10 and this PR.